### PR TITLE
flutter-elinux fork: update most URLs to github.com/flutter-elinux

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
       #  unzip linux-x64-embedder
       #  mv libflutter_engine.so ${{github.workspace}}/build
       run: |
-        curl -L https://github.com/sony/flutter-embedded-linux/releases/latest/download/elinux-x64-release.zip > elinux-x64-release.zip
+        curl -L https://github.com/flutter-elinux/flutter-embedded-linux/releases/latest/download/elinux-x64-release.zip > elinux-x64-release.zip
         unzip elinux-x64-release.zip
         mv libflutter_engine.so ${{github.workspace}}/build
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Athaariq Ardhiansyah <foss@athaariq.my.id>
 Anton Sakhon <kofhein@gmail.com>
 Bari Rao <bari.rao@gmail.com>
 Frede Emil Hoey Braendstrup <frederikbraendstrup@gmail.com>
+Dominique Martinet <dominique.martinet@atmark-techno.com>

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Embedded Linux (eLinux) embedding for Flutter
-![image](https://github.com/sony/flutter-elinux/blob/main/doc/images/overview.png)
+![image](https://github.com/flutter-elinux/flutter-elinux/blob/main/doc/images/overview.png)
 
-[![build-test](https://github.com/sony/flutter-embedded-linux/actions/workflows/build-test.yml/badge.svg)](https://github.com/sony/flutter-embedded-linux/actions/workflows/build-test.yml)
+[![build-test](https://github.com/flutter-elinux/flutter-embedded-linux/actions/workflows/build-test.yml/badge.svg)](https://github.com/flutter-elinux/flutter-embedded-linux/actions/workflows/build-test.yml)
 
 This project was created to develop **non-official** embedded Linux embeddings of [Flutter](https://flutter.dev/). This embedder is focusing on embedded Linux (eLinux) system use cases. It is also implemented based on Flutter desktop for Windows and has some unique features to use it in embedded systems.
 
-If you develop flutter apps for eLinux, use [flutter-elinux](https://github.com/sony/flutter-elinux), which is a non-official extension to the [Flutter SDK](https://github.com/flutter/flutter) to build and debug Flutter apps for embedded Linux devices.
+If you develop flutter apps for eLinux, use [flutter-elinux](https://github.com/flutter-elinux/flutter-elinux), which is a non-official extension to the [Flutter SDK](https://github.com/flutter/flutter) to build and debug Flutter apps for embedded Linux devices.
 
 ### Repositories
 
-- [flutter-elinux](https://github.com/sony/flutter-elinux): Flutter tools for eLinux
-- [flutter-elinux-plugins](https://github.com/sony/flutter-elinux-plugins): Flutter plugins for eLinux
-- [flutter-embedded-linux](https://github.com/sony/flutter-embedded-linux): eLinux embedding for Flutter
-- [meta-flutter](https://github.com/sony/meta-flutter): Yocto recipes of eLinux embedding for Flutter
+- [flutter-elinux](https://github.com/flutter-elinux/flutter-elinux): Flutter tools for eLinux
+- [flutter-elinux-plugins](https://github.com/flutter-elinux/flutter-elinux-plugins): Flutter plugins for eLinux
+- [flutter-embedded-linux](https://github.com/flutter-elinux/flutter-embedded-linux): eLinux embedding for Flutter
+- [meta-flutter](https://github.com/flutter-elinux/meta-flutter): Yocto recipes of eLinux embedding for Flutter
 
 ## Objective & Goal
 Our objective is to use Flutter in embedded systems. We're developing this embedder to use Flutter in embedded products. Ultimately we would like to propose and contribute this software to the mainline of [Flutter Engine](https://github.com/flutter/engine), which means we would like to add an embedded systems version into the Flutter repo for all embedded developers. Please note that this is just our ideal, not the official opinion of the Flutter community.
@@ -37,7 +37,11 @@ We would be grateful if you could give us feedback on bugs and new feature reque
   - APIs such as MethodChannel and EventChannel are completely the same with them
 
 ## Documentation
-Documentation for this software can be found at [Wiki](https://github.com/sony/flutter-embedded-linux/wiki).
+Documentation for this software can be found at [Wiki](https://github.com/flutter-elinux/flutter-embedded-linux/wiki).
 
 ## Supported platforms
-This embedder supports x64 and Arm64 (aarch64, ARMv8) architectures on Linux which supports either Wayland backend or DRM backend. See [Support status](https://github.com/sony/flutter-elinux/wiki/Support-status) for details.
+This embedder supports x64 and Arm64 (aarch64, ARMv8) architectures on Linux which supports either Wayland backend or DRM backend. See [Support status](https://github.com/flutter-elinux/flutter-elinux/wiki/Support-status) for details.
+
+## Thanks
+
+This repository was previously hosted on [sony/flutter-embedded-linux](https://github.com/sony/flutter-embedded-linux). Thanks to sony for creating this fork and maintaining it for 4 years.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,11 +4,11 @@
 These are an example of how to use embedded Linux embedding for Flutter.
 
 ## Each backend examples
-- [flutter-wayland-client](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-wayland-client): Wayland client app
-- [flutter-drm-gbm-backend](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-drm-gbm-backend): Fullscreen app on DRM backend with GBM
-- [flutter-drm-eglstream-backend](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-drm-eglstream-backend): Fullscreen app on DRM backend with EGLStream
-- [flutter-x11-client](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-x11-client): X11 client app
+- [flutter-wayland-client](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-wayland-client): Wayland client app
+- [flutter-drm-gbm-backend](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-drm-gbm-backend): Fullscreen app on DRM backend with GBM
+- [flutter-drm-eglstream-backend](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-drm-eglstream-backend): Fullscreen app on DRM backend with EGLStream
+- [flutter-x11-client](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-x11-client): X11 client app
 
 ## Examples using Flutter Plugins
-- [flutter-video-player-plugin](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-video-player-plugin): Flutter video player plugin
-- [flutter-external-texture-plugin](https://github.com/sony/flutter-embedded-linux/tree/master/examples/flutter-external-texture-plugin): Flutter external texture plugin
+- [flutter-video-player-plugin](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-video-player-plugin): Flutter video player plugin
+- [flutter-external-texture-plugin](https://github.com/flutter-elinux/flutter-embedded-linux/tree/master/examples/flutter-external-texture-plugin): Flutter external texture plugin

--- a/examples/flutter-drm-eglstream-backend/cmake/user_config.cmake
+++ b/examples/flutter-drm-eglstream-backend/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE DRM-EGLSTREAM)
 set(USE_GLES3 OFF)

--- a/examples/flutter-drm-gbm-backend/cmake/user_config.cmake
+++ b/examples/flutter-drm-gbm-backend/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE DRM-GBM)
 set(USE_GLES3 OFF)

--- a/examples/flutter-external-texture-plugin/cmake/user_config.cmake
+++ b/examples/flutter-external-texture-plugin/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE WAYLAND)
 set(USE_GLES3 OFF)

--- a/examples/flutter-video-player-plugin/README.md
+++ b/examples/flutter-video-player-plugin/README.md
@@ -1,7 +1,7 @@
 # Overview
 Flutter video player example using video player plugin for Embedded Linux. The interface of the plugin is compatible with [the Flutter official video player plugin](https://github.com/flutter/plugins/tree/master/packages/video_player/video_player).
 
-Note that this is just example for eLinux embedder, so please use [sony/flutter-elinux-plugins/packages/video_player](https://github.com/sony/flutter-elinux-plugins/tree/main/packages/video_player)
+Note that this is just example for eLinux embedder, so please use [sony/flutter-elinux-plugins/packages/video_player](https://github.com/flutter-elinux/flutter-elinux-plugins/tree/main/packages/video_player)
 
 ![image](https://user-images.githubusercontent.com/62131389/124210378-43f06400-db26-11eb-8723-40dad0eb67b0.png)
 

--- a/examples/flutter-video-player-plugin/cmake/user_config.cmake
+++ b/examples/flutter-video-player-plugin/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE WAYLAND)
 set(USE_GLES3 OFF)

--- a/examples/flutter-wayland-client/cmake/user_config.cmake
+++ b/examples/flutter-wayland-client/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE WAYLAND)
 set(USE_GLES3 OFF)

--- a/examples/flutter-x11-client/cmake/user_config.cmake
+++ b/examples/flutter-x11-client/cmake/user_config.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Flutter embedder configurations.
-# See: https://github.com/sony/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
+# See: https://github.com/flutter-elinux/flutter-embedded-linux/wiki/Building-Embedded-Linux-embedding-for-Flutter#user-configuration-parameters-cmake-options
 set(BACKEND_TYPE X11)
 set(USE_GLES3 OFF)


### PR DESCRIPTION
issues do not exist in flutter-elinux repo, so original sony links were kept

Also give thanks to sony for creating the fork