### PR TITLE
use egl platform display

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Anton Sakhon <kofhein@gmail.com>
 Bari Rao <bari.rao@gmail.com>
 Frede Emil Hoey Braendstrup <frederikbraendstrup@gmail.com>
 Dominique Martinet <dominique.martinet@atmark-techno.com>
+Wang Bin <wbsecg1@gmail.com>

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1443,7 +1443,8 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
   wl_surface_commit(native_window_->Surface());
 
   render_surface_ = std::make_unique<SurfaceGl>(std::make_unique<ContextEgl>(
-      std::make_unique<EnvironmentEgl>(wl_display_), enable_impeller));
+      std::make_unique<EnvironmentEgl>(EGL_PLATFORM_WAYLAND_KHR, wl_display_),
+      enable_impeller));
   render_surface_->SetNativeWindow(native_window_.get());
 
   if (view_properties_.use_window_decoration) {

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_x11.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_x11.cc
@@ -125,7 +125,8 @@ bool ELinuxWindowX11::CreateRenderSurface(int32_t width,
                                           int32_t height,
                                           bool enable_impeller) {
   auto context_egl = std::make_unique<ContextEgl>(
-      std::make_unique<EnvironmentEgl>(display_), enable_impeller);
+      std::make_unique<EnvironmentEgl>(EGL_PLATFORM_X11_KHR, display_),
+      enable_impeller);
 
   if (current_rotation_ == 90 || current_rotation_ == 270) {
     std::swap(width, height);

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_drm_gbm.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_drm_gbm.cc
@@ -134,7 +134,8 @@ bool NativeWindowDrmGbm::DismissCursor() {
 std::unique_ptr<SurfaceGl> NativeWindowDrmGbm::CreateRenderSurface(
     bool enable_impeller) {
   return std::make_unique<SurfaceGl>(std::make_unique<ContextEgl>(
-      std::make_unique<EnvironmentEgl>(gbm_device_), enable_impeller));
+      std::make_unique<EnvironmentEgl>(EGL_PLATFORM_GBM_KHR, gbm_device_),
+      enable_impeller));
 }
 
 bool NativeWindowDrmGbm::IsNeedRecreateSurfaceAfterResize() const {

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
@@ -35,7 +35,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
           compositor, subcompositor, root_surface, width_dip * pixel_ratio,
           kTitleBarHeightDIP * pixel_ratio, enable_vsync),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
-          std::make_unique<EnvironmentEgl>(display, sub_egl_display),
+          std::make_unique<EnvironmentEgl>(EGL_PLATFORM_WAYLAND_KHR, display,
+                                           sub_egl_display),
           enable_impeller)));
   titlebar_->SetPosition(0, -kTitleBarHeightDIP);
 
@@ -48,7 +49,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
           kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio,
           enable_vsync),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
-          std::make_unique<EnvironmentEgl>(display, sub_egl_display),
+          std::make_unique<EnvironmentEgl>(EGL_PLATFORM_WAYLAND_KHR, display,
+                                           sub_egl_display),
           enable_impeller))));
   buttons_[type]->SetPosition(
       width_dip * pixel_ratio - kButtonWidthDIP - kButtonMarginDIP,
@@ -63,7 +65,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
           kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio,
           enable_vsync),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
-          std::make_unique<EnvironmentEgl>(display, sub_egl_display),
+          std::make_unique<EnvironmentEgl>(EGL_PLATFORM_WAYLAND_KHR, display,
+                                           sub_egl_display),
           enable_impeller))));
   buttons_[type]->SetPosition(
       width_dip * pixel_ratio - kButtonWidthDIP * 2 - kButtonMarginDIP * 2,
@@ -78,7 +81,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
           kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio,
           enable_vsync),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
-          std::make_unique<EnvironmentEgl>(display, sub_egl_display),
+          std::make_unique<EnvironmentEgl>(EGL_PLATFORM_WAYLAND_KHR, display,
+                                           sub_egl_display),
           enable_impeller))));
   buttons_[type]->SetPosition(
       width_dip * pixel_ratio - kButtonWidthDIP * 3 - kButtonMarginDIP * 3,


### PR DESCRIPTION
required if mutiple platforms are available, otherwise egl may call into x11 and crash even if gbm is desired. tested on rk3588