### PR TITLE
Use bookworm base image for glibc 2.36 compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Anton Sakhon <kofhein@gmail.com>
 Bari Rao <bari.rao@gmail.com>
 Frede Emil Hoey Braendstrup <frederikbraendstrup@gmail.com>
 Dominique Martinet <dominique.martinet@atmark-techno.com>
+Kareem Abdelhalem <kareem.abdelhalem@gmail.com>

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
The current `13e658725d` artifacts require glibc 2.38 and GLIBCXX 3.4.32, which limits deployment to Debian Trixie or Ubuntu 24.04+. Many embedded devices (e.g., Raspberry Pi) still run Debian 12 Bookworm.

 Building with Bookworm produces artifacts requiring only:
  - GLIBC_2.32
  - GLIBCXX_3.4.29

Both are available in Debian 12 Bookworm (glibc 2.36, GLIBCXX 3.4.31).

I have tested changes by building artifacts locally and verifying artifact requirements via `objdump -T`:
    - Max GLIBC required: 2.32
    - Max GLIBCXX required: 3.4.29


Ref: flutter-elinux/flutter-elinux#2 (discussion about rebuilding with older distro for compatibility)