### PR TITLE
release: use old bullseye container for release build

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,18 +1,55 @@
-FROM debian:trixie-slim
+# Build releases with the oldest possible supported target
+# The built binaries will depend on symbols from the libc used here,
+# so this should work on newer OS but might not work on older OS
+
+# Recommended version should be kept in sync with the wiki:
+# https://github.com/flutter-elinux/flutter-elinux/wiki/flutter-elinux-install
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN <<EOF
 dpkg --add-architecture arm64
+
 apt-get update
 apt-get -y -q upgrade
-apt-get -y install                \
-       crossbuild-essential-arm64        \
-       cmake                             \
-       git                          \
-       xxhash                       \
-       curl xz-utils build-essential pkgconf \
-       zip equivs clang libgles2-mesa-dev wayland-protocols libegl1-mesa-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libsystemd-dev libxkbcommon-dev libwayland-dev  \
-       libgles2-mesa-dev:arm64 wayland-protocols:arm64 libegl1-mesa-dev:arm64 libdrm-dev:arm64 libgbm-dev:arm64 libinput-dev:arm64 libudev-dev:arm64 libsystemd-dev:arm64 libxkbcommon-dev:arm64 libwayland-dev:arm64 libuv1-dev:arm64
+
+apt-get -y install			\
+	build-essential			\
+	clang				\
+	cmake				\
+	crossbuild-essential-arm64	\
+	curl				\
+	equivs				\
+	git				\
+	libdrm-dev			\
+	libdrm-dev:arm64		\
+	libegl1-mesa-dev		\
+	libegl1-mesa-dev:arm64		\
+	libgbm-dev			\
+	libgbm-dev:arm64		\
+	libgles2-mesa-dev		\
+	libgles2-mesa-dev:arm64		\
+	libinput-dev			\
+	libinput-dev:arm64		\
+	libsystemd-dev			\
+	libsystemd-dev:arm64		\
+	libudev-dev			\
+	libudev-dev:arm64		\
+	libuv1-dev:arm64		\
+	libwayland-dev			\
+	libwayland-dev:arm64		\
+	libxkbcommon-dev		\
+	libxkbcommon-dev:arm64		\
+	pkgconf				\
+	wayland-protocols		\
+	wayland-protocols:arm64		\
+	xxhash				\
+	xz-utils			\
+	zip
+
+# not needed for trixie
+apt-get -y install libstdc++-10-dev:arm64
+
 apt-get clean
 EOF

--- a/release/README.md
+++ b/release/README.md
@@ -6,10 +6,7 @@ To run with docker:
 # build container
 docker build -t flutter-build .
 # build flutter engine and flutter-elinux variants
-docker run -ti --rm --user "$(id -u):$(id -g)" \
-    -v "$PWD":/flutter -w /flutter \
-    --env HOME=/flutter/home flutter-build \
-    ./build-all.sh [build-all options]
+./run-docker.sh ./build-all.sh [build-all options]
 # check build is complete and output instructions to make release
 ./prepare-release.sh output
 ```

--- a/release/run-docker.sh
+++ b/release/run-docker.sh
@@ -1,6 +1,8 @@
+#!/bin/sh
+
 docker run -ti --rm \
 	--user "$(id -u):$(id -g)" \
 	-v "$PWD":/flutter \
 	-w /flutter \
 	--env HOME=/flutter/home \
-	flutter
+	flutter-build "$@"

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc
@@ -13,6 +13,13 @@
 #include "flutter/shell/platform/linux_embedded/logger.h"
 #include "flutter/shell/platform/linux_embedded/surface/cursor_data.h"
 
+// Allow building with mesa < 21
+// This is a linux uapi header value so there is no risk in hardcoding it if
+// unset
+#ifdef DRM_MODE_CONNECTOR_USB
+#define DRM_MODE_CONNECTOR_USB 20
+#endif
+
 namespace flutter {
 namespace {
 constexpr char kFlutterDrmConnectorEnvironmentKey[] = "FLUTTER_DRM_CONNECTOR";


### PR DESCRIPTION
Building with trixie requires a recent glibc/stdc++ environment
(GLIBC_2.38 / GLIBCXX_3.4.32), which might not be available on the
target environment.

Conversely, as far as libc/stdlib are concerned we are guarnateed to be
able to run an old binary on a newer system, so building on a system as
old as possible should address this particular issue.

Unfortunately libflutter*so also link against system libraries
(GL, X, wayland, fontconfig and many others), so if there is any so bump
or imcompatible ABI then this is still far from perfect:
future improvement should rebuild flutter-embedded-linux on demand for
the required target, from flutter-elinux's CMake configuration

The elinux embedded itself is not hard to build but libflutter_engine.so
will be more work, so settle with "back to the old state" level for now.


---------

Bullseye build broke on a single point, so there's a prerequisite patch, but it's trivial enough and should not be a problem.

I've tested running this on bullseye and on trixie so don't expect any problem with anything in between, this will be enough for the next immediate release.

I was also more annoyed than I thought I'd be at the bigger flutter engine .so release size since 3.32 (for example the arm64 debug libflutter_engine.so went from 83MB to 385MB!!!), so I'd like to have a look at that before the next release....
Hopefully by next week.

Cc @kabdelhalem -- thanks again, sorry to override your PR
