### PR TITLE
release: strip flutter engine .so again

### DIFF
--- a/release/build-flutter-engine.sh
+++ b/release/build-flutter-engine.sh
@@ -132,17 +132,16 @@ else
 	RELEASE_OUTDIR="host_release"
 fi
 
-
 # debug mode
-./flutter/tools/gn --runtime-mode debug ${ARCH_OPTION} --unoptimized --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma
+./flutter/tools/gn --runtime-mode debug ${ARCH_OPTION} --unoptimized --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma --stripped
 ninja -C out/${DEBUG_OUTDIR}
 
 # profile mode
-./flutter/tools/gn --runtime-mode profile ${ARCH_OPTION} --no-lto --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma
+./flutter/tools/gn --runtime-mode profile ${ARCH_OPTION} --no-lto --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma --stripped
 ninja -C out/${PROFILE_OUTDIR}
 
 # release mode
-./flutter/tools/gn --runtime-mode release ${ARCH_OPTION} --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma
+./flutter/tools/gn --runtime-mode release ${ARCH_OPTION} --embedder-for-target --disable-desktop-embeddings --no-build-embedder-examples --enable-fontconfig --no-goma --stripped
 ninja -C out/${RELEASE_OUTDIR}
 
 popd


### PR DESCRIPTION
release build got much bigger since flutter 3.32 (for debug it went from 83MB to 385MB)
This is apparently just because the lib is no longer stripped since [1]

This looks like a bug since we don't target android (tentative fix in [2]), but until that lands just set --stripped manually. Even if there is no C symbol dart stacktraces are available so most people don't need these.

Link: https://github.com/flutter/flutter/pull/161546 [1]
Link: https://github.com/flutter/flutter/pull/181984 [2]