### PR TITLE
Fix cursor_info_.pointer dangling pointer on device disconnect (wayland)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Frede Emil Hoey Braendstrup <frederikbraendstrup@gmail.com>
 Dominique Martinet <dominique.martinet@atmark-techno.com>
 Wang Bin <wbsecg1@gmail.com>
 Jón Bjarni Bjarnason <jon@centroid.is>
+Fredrik Magnussen <fredrik.magnussen@biomerieux.com>

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -303,7 +303,6 @@ const wl_seat_listener ELinuxWindowWayland::kWlSeatListener = {
       } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && inputs.pointer) {
         ELINUX_LOG(TRACE) << "Pointer device disconnecting: " << inputs.pointer;
         if (self->cursor_info_.pointer == inputs.pointer) {
-          ELINUX_LOG(TRACE) << "Clearing cursor_info_.pointer to prevent dangling pointer";
           self->cursor_info_.pointer = nullptr;
         }
         wl_pointer_release(inputs.pointer);
@@ -1533,7 +1532,6 @@ void ELinuxWindowWayland::UpdateVirtualKeyboardStatus(
 void ELinuxWindowWayland::UpdateFlutterCursor(const std::string& cursor_name) {
   if (view_properties_.use_mouse_cursor) {
     if (!cursor_info_.pointer) {
-      ELINUX_LOG(TRACE) << "UpdateFlutterCursor called but pointer is null (device disconnected)";
       return;
     }
     if (cursor_name.compare(cursor_info_.cursor_name) == 0) {


### PR DESCRIPTION
First of all, thank you for taking the initiative to create a public fork of the flutter-elinux project.

Fixes https://github.com/sony/flutter-embedded-linux/issues/436. The issue was originally fixed in https://github.com/sony/flutter-embedded-linux/issues/403, but seems to have been reintroduced.

Prevents crashes by clearing cursor_info_.pointer when the pointer device (e.g., a mouse) disconnects and adding null check in UpdateFlutterCursor.

Changes:

- Clear cursor_info_.pointer when WL_SEAT_CAPABILITY_POINTER is removed
- Add null check in UpdateFlutterCursor before accessing pointer