### PR TITLE
Check CreateRenderSurface() return value

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
@@ -95,7 +95,10 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
   // Take ownership of the engine, starting it if necessary.
   state->view->SetEngine(
       std::unique_ptr<flutter::FlutterELinuxEngine>(EngineFromHandle(engine)));
-  state->view->CreateRenderSurface();
+  if (!state->view->CreateRenderSurface()) {
+    return nullptr;
+  }
+
   if (!state->view->GetEngine()->running()) {
     if (!state->view->GetEngine()->RunWithEntrypoint(nullptr)) {
       return nullptr;


### PR DESCRIPTION
Early fail if we are unable to create a render surface to avoid nullptr dereference crashes further down the track.

Fixes: #14