### PR TITLE
fix: fullscreen surface oversized when --force-scale-factor is set (#329)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1400,8 +1400,8 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
   }
 
   if (view_properties_.view_mode == FlutterDesktopViewMode::kFullscreen) {
-    if (view_properties_.force_scale_factor &&
-        display_max_width_ > 0 && display_max_height_ > 0) {
+    if (view_properties_.force_scale_factor && display_max_width_ > 0 &&
+        display_max_height_ > 0) {
       // When force_scale_factor is active, the surface must be the native
       // display resolution (display_max). Using display_max directly avoids
       // floating-point rounding when current_scale_ is non-integer (e.g. 1.3).

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -687,8 +687,20 @@ const wl_output_listener ELinuxWindowWayland::kWlOutputListener = {
 
         if (self->view_properties_.view_mode ==
             FlutterDesktopViewMode::kFullscreen) {
-          self->view_properties_.width = width;
-          self->view_properties_.height = height;
+          if (self->view_properties_.force_scale_factor) {
+            // force_scale_factor adjusts the Flutter engine's device pixel
+            // ratio only; it does not scale the surface buffer. Store the
+            // display dimensions as logical DIP so that the invariant
+            // view_properties_.width * current_scale_ == native_px holds,
+            // consistent with xdg_toplevel_listener.configure.
+            self->view_properties_.width =
+                static_cast<int32_t>(width / self->current_scale_);
+            self->view_properties_.height =
+                static_cast<int32_t>(height / self->current_scale_);
+          } else {
+            self->view_properties_.width = width;
+            self->view_properties_.height = height;
+          }
           self->request_redraw_ = true;
         }
 
@@ -1388,8 +1400,17 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
   }
 
   if (view_properties_.view_mode == FlutterDesktopViewMode::kFullscreen) {
-    width_px = view_properties_.width * current_scale_;
-    height_px = view_properties_.height * current_scale_;
+    if (view_properties_.force_scale_factor &&
+        display_max_width_ > 0 && display_max_height_ > 0) {
+      // When force_scale_factor is active, the surface must be the native
+      // display resolution (display_max). Using display_max directly avoids
+      // floating-point rounding when current_scale_ is non-integer (e.g. 1.3).
+      width_px = display_max_width_;
+      height_px = display_max_height_;
+    } else {
+      width_px = view_properties_.width * current_scale_;
+      height_px = view_properties_.height * current_scale_;
+    }
   }
 
   ELINUX_LOG(TRACE) << "Created the Wayland surface: " << width_px << "x"


### PR DESCRIPTION
## Summary

When `--fullscreen` and `--force-scale-factor=N` are combined, the Wayland surface was created at `native_width*N x native_height*N` instead of the native display resolution. For example, a 800×480 display with `--force-scale-factor=1.3` produced a 1040×624 surface, causing UI to render partially off-screen.

## Root Cause

`wl_output_listener.mode` stored the native display pixels directly in `view_properties_.width/height` for the fullscreen case, but the rest of the codebase treats `view_properties_` as logical DIP. The subsequent multiplication by `current_scale_` in `CreateRenderSurface` then over-scaled the surface dimensions.

`force_scale_factor` is intended to adjust the Flutter engine's device pixel ratio (DPR) so that UI elements appear larger — not to increase the surface buffer beyond the display's native resolution.

## Fix

1. `wl_output_listener.mode`: when `force_scale_factor` is set, store display dimensions as logical DIP (`width / current_scale_`), consistent with `xdg_toplevel_listener.configure` which already does this.
2. `CreateRenderSurface`: when `force_scale_factor` is set and `display_max` dimensions are known, use `display_max` directly to avoid float rounding.

**1 file changed** (`elinux_window_wayland.cc`), +25/-4 lines

Closes #329

Signed-off-by: Akihiko Komada <aki1770@gmail.com>