### PR TITLE
fix: clear cursor_info pointer on wl_pointer release to prevent use-after-free (#436)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1742,6 +1742,9 @@ void ELinuxWindowWayland::WlUnRegistryHandler(wl_registry* wl_registry,
     if (seat_inputs_iter != seat_inputs_map_.end()) {
       auto& inputs = seat_inputs_iter->second;
       if (inputs.pointer) {
+        if (cursor_info_.pointer == inputs.pointer) {
+          cursor_info_.pointer = nullptr;
+        }
         wl_pointer_release(inputs.pointer);
         inputs.pointer = nullptr;
       }


### PR DESCRIPTION
## Summary

When a Wayland seat is removed (`wl_registry::global_remove`) or loses its pointer capability (`wl_seat_listener::capabilities`), `wl_pointer_release()` frees the `wl_pointer` object. `cursor_info_.pointer`, which caches the same pointer from the most recent `wl_pointer_listener::enter` event, was not cleared in the `WlUnRegistryHandler` path.

The next call to `UpdateFlutterCursor()` would pass the freed pointer to `wl_pointer_set_cursor()` — a use-after-free that causes a segmentation fault.

## Fix

Before calling `wl_pointer_release()` in `WlUnRegistryHandler`, check whether `cursor_info_.pointer` holds the same address and clear it if so.

**1 file changed** (`elinux_window_wayland.cc`), +3 lines

Closes #436

Signed-off-by: Akihiko Komada <aki1770@gmail.com>