### PR TITLE
feat: add disable_dirty_region_management option to fix flickering on iMX8MP (#334)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -120,6 +120,13 @@ typedef struct {
   // True:  Sync to compositor redraw/v-blank  (eglSwapInterval 1)
   // False: Do not sync to compositor redraw/v-blank (eglSwapInterval 0)
   bool enable_vsync;
+
+  // Disable dirty region management (EGL partial update).
+  // Set true to always perform full-screen repaints and EGL full swaps.
+  // Workaround for GPU drivers that mishandle EGL_KHR_partial_update
+  // (e.g. iMX8MP / NXP Vivante). False by default (management enabled).
+  // See: https://github.com/sony/flutter-embedded-linux/issues/334
+  bool disable_dirty_region_management;
 } FlutterDesktopViewProperties;
 
 // ========== View Controller ==========

--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl.cc
@@ -118,8 +118,9 @@ std::unique_ptr<ELinuxEGLSurface> ContextEgl::CreateOnscreenSurface(
     ELINUX_LOG(ERROR) << "Failed to create EGL window surface: "
                       << get_egl_error_cause();
   }
-  return std::make_unique<ELinuxEGLSurface>(surface, environment_->Display(),
-                                            context_, window->EnableVsync());
+  return std::make_unique<ELinuxEGLSurface>(
+      surface, environment_->Display(), context_, window->EnableVsync(),
+      !window->IsDirtyRegionManagementDisabled());
 }
 
 std::unique_ptr<ELinuxEGLSurface> ContextEgl::CreateOffscreenSurface(
@@ -150,9 +151,9 @@ std::unique_ptr<ELinuxEGLSurface> ContextEgl::CreateOffscreenSurface(
                         << get_egl_error_cause() << ")";
   }
 #endif
-  return std::make_unique<ELinuxEGLSurface>(surface, environment_->Display(),
-                                            resource_context_,
-                                            window->EnableVsync());
+  return std::make_unique<ELinuxEGLSurface>(
+      surface, environment_->Display(), resource_context_,
+      window->EnableVsync(), !window->IsDirtyRegionManagementDisabled());
 }
 
 bool ContextEgl::IsValid() const {

--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
@@ -19,31 +19,35 @@ constexpr const int kMaxHistorySize = 10;
 ELinuxEGLSurface::ELinuxEGLSurface(EGLSurface surface,
                                    EGLDisplay display,
                                    EGLContext context,
-                                   bool vsync_enabled)
+                                   bool vsync_enabled,
+                                   bool dirty_region_management_enabled)
     : surface_(surface),
       display_(display),
       context_(context),
       vsync_enabled_(vsync_enabled),
+      dirty_region_management_enabled_(dirty_region_management_enabled),
       width_px_(kInitialWindowWidthPx),
       height_px_(kInitialWindowHeightPx) {
-  const char* extensions = eglQueryString(display_, EGL_EXTENSIONS);
+  if (dirty_region_management_enabled_) {
+    const char* extensions = eglQueryString(display_, EGL_EXTENSIONS);
 
-  if (has_egl_extension(extensions, "EGL_KHR_partial_update")) {
-    eglSetDamageRegionKHR_ = reinterpret_cast<PFNEGLSETDAMAGEREGIONKHRPROC>(
-        eglGetProcAddress("eglSetDamageRegionKHR"));
-  }
+    if (has_egl_extension(extensions, "EGL_KHR_partial_update")) {
+      eglSetDamageRegionKHR_ = reinterpret_cast<PFNEGLSETDAMAGEREGIONKHRPROC>(
+          eglGetProcAddress("eglSetDamageRegionKHR"));
+    }
 
-  if (has_egl_extension(extensions, "EGL_EXT_swap_buffers_with_damage")) {
-    eglSwapBuffersWithDamageEXT_ =
-        reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(
-            eglGetProcAddress("eglSwapBuffersWithDamageEXT"));
-  } else if (has_egl_extension(extensions,
-                               "EGL_KHR_swap_buffers_with_damage")) {
-    eglSwapBuffersWithDamageEXT_ =
-        reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(
-            eglGetProcAddress("eglSwapBuffersWithDamageKHR"));
-  } else {
-    // do nothing.
+    if (has_egl_extension(extensions, "EGL_EXT_swap_buffers_with_damage")) {
+      eglSwapBuffersWithDamageEXT_ =
+          reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(
+              eglGetProcAddress("eglSwapBuffersWithDamageEXT"));
+    } else if (has_egl_extension(extensions,
+                                 "EGL_KHR_swap_buffers_with_damage")) {
+      eglSwapBuffersWithDamageEXT_ =
+          reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(
+              eglGetProcAddress("eglSwapBuffersWithDamageKHR"));
+    } else {
+      // do nothing.
+    }
   }
 };
 
@@ -128,9 +132,11 @@ bool ELinuxEGLSurface::SwapBuffers(const FlutterPresentInfo* info) {
   }
 
   // Add frame damage to damage history
-  damage_history_.push_back(info->frame_damage.damage[0]);
-  if (damage_history_.size() > kMaxHistorySize) {
-    damage_history_.pop_front();
+  if (dirty_region_management_enabled_) {
+    damage_history_.push_back(info->frame_damage.damage[0]);
+    if (damage_history_.size() > kMaxHistorySize) {
+      damage_history_.pop_front();
+    }
   }
 
   if (eglSwapBuffersWithDamageEXT_) {
@@ -155,15 +161,6 @@ bool ELinuxEGLSurface::SwapBuffers(const FlutterPresentInfo* info) {
 
 void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
                                               FlutterDamage* existing_damage) {
-  // Given the FBO age, create existing damage region by joining all frame
-  // damages since FBO was last used
-  EGLint age = 0;
-  if (eglQuerySurface(display_, surface_, EGL_BUFFER_AGE_EXT, &age) !=
-          EGL_TRUE ||
-      age == 0) {
-    age = 4;  // Virtually no driver should have a swapchain length > 4.
-  }
-
   existing_damage->num_rects = 1;
 
   // Allocate the array of rectangles for the existing damage.
@@ -173,6 +170,23 @@ void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
   existing_damage_map_[fbo_id][0] = FlutterRect{
       0, 0, static_cast<double>(width_px_), static_cast<double>(height_px_)};
   existing_damage->damage = existing_damage_map_[fbo_id];
+
+  if (!dirty_region_management_enabled_) {
+    // Dirty region management disabled: always report full-screen damage so
+    // the engine performs a full repaint. This is a workaround for GPU drivers
+    // that mishandle EGL_KHR_partial_update (e.g. iMX8MP / NXP Vivante).
+    // See: https://github.com/sony/flutter-embedded-linux/issues/334
+    return;
+  }
+
+  // Given the FBO age, create existing damage region by joining all frame
+  // damages since FBO was last used
+  EGLint age = 0;
+  if (eglQuerySurface(display_, surface_, EGL_BUFFER_AGE_EXT, &age) !=
+          EGL_TRUE ||
+      age == 0) {
+    age = 4;  // Virtually no driver should have a swapchain length > 4.
+  }
 
   if (age > 1) {
     --age;

--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.h
@@ -22,7 +22,8 @@ class ELinuxEGLSurface {
   ELinuxEGLSurface(EGLSurface surface,
                    EGLDisplay display,
                    EGLContext context,
-                   bool vsync_enabled);
+                   bool vsync_enabled,
+                   bool dirty_region_management_enabled = true);
   ~ELinuxEGLSurface();
 
   bool IsValid() const;
@@ -47,6 +48,7 @@ class ELinuxEGLSurface {
   EGLSurface surface_;
   EGLContext context_;
   bool vsync_enabled_;
+  bool dirty_region_management_enabled_;
 
   size_t width_px_;
   size_t height_px_;

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1407,7 +1407,8 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
     std::swap(width_px, height_px);
   }
   native_window_ = std::make_unique<NativeWindowWayland>(
-      wl_compositor_, width_px, height_px, view_properties_.enable_vsync);
+      wl_compositor_, width_px, height_px, view_properties_.enable_vsync,
+      view_properties_.disable_dirty_region_management);
 
   wl_surface_add_listener(native_window_->Surface(), &kWlSurfaceListener, this);
 

--- a/src/flutter/shell/platform/linux_embedded/window/native_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window.h
@@ -39,6 +39,10 @@ class NativeWindow {
 
   bool EnableVsync() const { return enable_vsync_; }
 
+  bool IsDirtyRegionManagementDisabled() const {
+    return disable_dirty_region_management_;
+  }
+
   virtual bool IsNeedRecreateSurfaceAfterResize() const { return false; }
 
   // Sets a window position. Basically, this API is used for window decorations
@@ -62,6 +66,7 @@ class NativeWindow {
   EGLNativeWindowType window_;
   EGLNativeWindowType window_offscreen_;
   bool enable_vsync_;
+  bool disable_dirty_region_management_ = false;
   // Physical width of the window.
   int32_t width_;
   // Physical height of the window.

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc
@@ -11,7 +11,8 @@ namespace flutter {
 NativeWindowWayland::NativeWindowWayland(wl_compositor* compositor,
                                          const size_t width_px,
                                          const size_t height_px,
-                                         bool enable_vsync) {
+                                         bool enable_vsync,
+                                         bool disable_dirty_region_management) {
   surface_ = wl_compositor_create_surface(compositor);
   if (!surface_) {
     ELINUX_LOG(ERROR) << "Failed to create the compositor surface.";
@@ -42,6 +43,7 @@ NativeWindowWayland::NativeWindowWayland(wl_compositor* compositor,
   }
 
   enable_vsync_ = enable_vsync;
+  disable_dirty_region_management_ = disable_dirty_region_management;
   width_ = width_px;
   height_ = height_px;
   valid_ = true;

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.h
@@ -18,7 +18,8 @@ class NativeWindowWayland : public NativeWindow {
   NativeWindowWayland(wl_compositor* compositor,
                       const size_t width_px,
                       const size_t height_px,
-                      bool enable_vsync);
+                      bool enable_vsync,
+                      bool disable_dirty_region_management = false);
   ~NativeWindowWayland();
 
   // |NativeWindow|


### PR DESCRIPTION
## Summary

Some GPU drivers (e.g. iMX8MP / NXP Vivante GC7000L) mishandle `EGL_KHR_partial_update`, causing display flickering when dirty region management is active. The Flutter engine's `embedder_surface_gl.cc` also hardcodes `supports_partial_repaint=true` (issue flutter/flutter#119601), making the build-time `USE_OPENGL_DIRTY_REGION_MANAGEMENT=OFF` insufficient.

## Fix

Add `disable_dirty_region_management` to `FlutterDesktopViewProperties`. When set to `true`:
- EGL damage extensions (`EGL_KHR_partial_update`, `EGL_EXT/KHR_swap_buffers_with_damage`) are not loaded, so `eglSwapBuffers` always performs a full swap.
- `PopulateExistingDamage` returns full-screen damage immediately.
- Frame damage history is not accumulated.

Existing behavior is fully preserved for all users who do not set this flag (zero-initialised = false = management enabled).

**8 files changed**, +71/-38 lines

Closes #334

Signed-off-by: Akihiko Komada <aki1770@gmail.com>