### PR TITLE
fix: repair three memory issues contributing to animated image leak (#429)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
@@ -166,6 +166,15 @@ void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
 
   existing_damage->num_rects = 1;
 
+  // Free any previous allocation for this FBO (defensive: guards against the
+  // engine calling populate without a subsequent present_with_info, which would
+  // otherwise orphan the malloc'd buffer).
+  auto it = existing_damage_map_.find(fbo_id);
+  if (it != existing_damage_map_.end() && it->second != nullptr) {
+    free(it->second);
+    it->second = nullptr;
+  }
+
   // Allocate the array of rectangles for the existing damage.
   existing_damage_map_[fbo_id] = static_cast<FlutterRect*>(
       malloc(sizeof(FlutterRect) * existing_damage->num_rects));

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -45,7 +45,7 @@ class ELinuxWindow {
   void NotifyDisplayInfoUpdates() const {
     if (binding_handler_delegate_) {
       binding_handler_delegate_->UpdateDisplayInfo(
-          std::trunc(1000000.0 / frame_rate_), GetCurrentWidth(),
+          static_cast<double>(frame_rate_) / 1000.0, GetCurrentWidth(),
           GetCurrentHeight(), current_scale_);
     }
   }

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -269,6 +269,7 @@ const wl_callback_listener ELinuxWindowWayland::kWlSurfaceFrameListener = {
           // by all compositors. This path is for when it wasn't supported.
           auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
           if (self->wp_presentation_clk_id_ != UINT32_MAX) {
+            wl_callback_destroy(wl_callback);
             return;
           }
 


### PR DESCRIPTION
## Summary

Fixes three converging bugs that cause `~3 MB/hr` memory leak with animated WebP images (100×100 pixels).

### Bug 1 — Wrong refresh rate units (`elinux_window.h`)

`frame_rate_` is in milliHz (e.g. 60000 for 60 Hz). `std::trunc(1000000.0 / frame_rate_)` yielded `~16` instead of `60`. `FlutterEngineDisplay.refresh_rate` expects frames-per-second. The engine used this to compute frame intervals for animated image scheduling.

Fix: `static_cast<double>(frame_rate_) / 1000.0`

### Bug 2 — Missing `wl_callback_destroy` (`elinux_window_wayland.cc`)

When `wp_presentation` is available, the `wl_surface_frame` callback `done` handler returns early without calling `wl_callback_destroy(wl_callback)`. The client-side `wl_proxy` object was leaked on every frame while `wp_presentation` is active.

Fix: add `wl_callback_destroy(wl_callback)` before the early return.

### Bug 3 — Orphaned `malloc` in `PopulateExistingDamage` (`elinux_egl_surface.cc`)

If the Flutter engine calls `PopulateExistingDamage` without a subsequent `present_with_info` (e.g. at shutdown or skipped frame), the previously `malloc`'d `FlutterRect` buffer is silently overwritten on the next call.

Fix: free the existing buffer before allocating a new one.

**3 files changed**, +11/-1 lines

Signed-off-by: Akihiko Komada <aki1770@gmail.com>