### PR TITLE
fix: resolve self-paste deadlock in GetClipboardData()

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1568,6 +1568,16 @@ void ELinuxWindowWayland::UpdateFlutterCursor(const std::string& cursor_name) {
 }
 
 std::string ELinuxWindowWayland::GetClipboardData() {
+  // If this application owns the current clipboard selection, return the
+  // locally cached data directly. Routing through the Wayland
+  // wl_data_offer_receive round-trip when source and consumer are the same
+  // process causes a deadlock: read() on the main thread blocks waiting for
+  // data that can only arrive after dispatching wl_data_source.send — which
+  // also runs on the main thread. See: issue #18.
+  if (wl_data_source_) {
+    return clipboard_data_;
+  }
+
   std::string str = "";
 
   if (wl_data_offer_) {


### PR DESCRIPTION
Fixes #18

## Problem

When an application copies text and then pastes it (self-paste on Wayland), `GetClipboardData()` deadlocks.

**Root cause**: `GetClipboardData()` calls `wl_data_offer_receive()` followed by a blocking `read()`. In the self-paste case, this application is both the clipboard owner (`wl_data_source_`) and the consumer. The compositor delivers data by sending a `wl_data_source.send` event to the owner, which writes to the pipe. But `wl_data_source.send` dispatches on the same main thread that is blocked in `read()` — neither unblocks the other.

```
Sequence (self-paste):
  GetClipboardData()
    wl_data_offer_receive(..., fd[1])   ← queues request to compositor
    close(fd[1])
    wl_display_dispatch()               ← returns before compositor responds
    read(fd[0])                         ← BLOCKS FOREVER
                                          (wl_data_source.send needs this
                                           same thread to dispatch and write)
```

## Fix

If `wl_data_source_` is non-null, this application owns the current selection and `clipboard_data_` holds the current content. Return it directly — no round-trip needed.

**`wl_data_source_` lifecycle**:
- Set in `SetClipboardData()` when we acquire the clipboard selection
- Cleared in `kWlDataSourceListener.cancelled` when another app takes the selection
- Invariant: `wl_data_source_ != nullptr` ↔ `clipboard_data_` holds the current clipboard text

The cross-application paste path (`wl_data_source_` null, another app owns the selection) is unchanged.

## Testing

- Self-paste: copy text in app → paste in same app → no longer deadlocks; correct text pasted
- Cross-app paste: copy in another app → paste in this app → existing path unchanged
- Empty clipboard: both `wl_data_source_` and `wl_data_offer_` null → returns empty string unchanged