### PR TITLE
fix: fullscreen surface oversized when --force-scale-factor is set (#329)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -685,29 +685,39 @@ const wl_output_listener ELinuxWindowWayland::kWlOutputListener = {
           self->frame_rate_ = refresh;
         }
 
+        // wl_output reports physical pixels; the rest of the codebase tracks
+        // view_properties_ as logical DIP (physical_px == DIP * current_scale_)
+        // — convert once so the storage and clipping below share units, and
+        // the invariant view_properties_.width * current_scale_ == native_px
+        // holds consistently with xdg_toplevel_listener.configure.
+        const int32_t width_dip =
+            static_cast<int32_t>(width / self->current_scale_);
+        const int32_t height_dip =
+            static_cast<int32_t>(height / self->current_scale_);
+
         if (self->view_properties_.view_mode ==
             FlutterDesktopViewMode::kFullscreen) {
-          self->view_properties_.width = width;
-          self->view_properties_.height = height;
+          self->view_properties_.width = width_dip;
+          self->view_properties_.height = height_dip;
           self->request_redraw_ = true;
         }
 
-        if (self->view_properties_.width > width) {
+        if (self->view_properties_.width > width_dip) {
           ELINUX_LOG(WARNING)
               << "Requested width size(" << self->view_properties_.width << ") "
-              << "is larger than display size(" << width
+              << "is larger than display size(" << width_dip
               << ")"
                  ", clipping";
-          self->view_properties_.width = width;
+          self->view_properties_.width = width_dip;
           self->request_redraw_ = true;
         }
-        if (self->view_properties_.height > height) {
+        if (self->view_properties_.height > height_dip) {
           ELINUX_LOG(WARNING)
               << "Requested height size(" << self->view_properties_.height
-              << ") " << "is larger than display size(" << height
+              << ") " << "is larger than display size(" << height_dip
               << ")"
                  ", clipping";
-          self->view_properties_.height = height;
+          self->view_properties_.height = height_dip;
           self->request_redraw_ = true;
         }
       }
@@ -1388,8 +1398,17 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
   }
 
   if (view_properties_.view_mode == FlutterDesktopViewMode::kFullscreen) {
-    width_px = view_properties_.width * current_scale_;
-    height_px = view_properties_.height * current_scale_;
+    if (view_properties_.force_scale_factor && display_max_width_ > 0 &&
+        display_max_height_ > 0) {
+      // When force_scale_factor is active, the surface must be the native
+      // display resolution (display_max). Using display_max directly avoids
+      // floating-point rounding when current_scale_ is non-integer (e.g. 1.3).
+      width_px = display_max_width_;
+      height_px = display_max_height_;
+    } else {
+      width_px = view_properties_.width * current_scale_;
+      height_px = view_properties_.height * current_scale_;
+    }
   }
 
   ELINUX_LOG(TRACE) << "Created the Wayland surface: " << width_px << "x"


### PR DESCRIPTION
Supersedes #20 — same fix as @aki1770-del proposed, with an additional cleanup to address the DIP-vs-px comparison I flagged in review. Opening here because `maintainerCanModify` on #20 returned 403 on push despite the API flag being set.

## Summary

When `--fullscreen` and `--force-scale-factor=N` are combined, the Wayland surface was created at `native_width*N × native_height*N` instead of the native display resolution. For example, an 800×480 display with `--force-scale-factor=1.3` produced a 1040×624 surface, causing UI to render partially off-screen.

## Root cause

`wl_output_listener.mode` stored the native display pixels directly in `view_properties_.width/height` for the fullscreen case, while the rest of the codebase treats `view_properties_` as logical DIP. The subsequent multiplication by `current_scale_` in `CreateRenderSurface` then over-scaled the surface dimensions.

`force_scale_factor` is intended to adjust the Flutter engine's device pixel ratio (DPR) so UI elements appear larger — not to inflate the surface buffer beyond the display's native resolution.

## Fix

1. **`wl_output_listener.mode`**: convert reported physical `width`/`height` to DIP once (`/ current_scale_`) and use that for both the fullscreen storage and the windowed-mode clipping comparison. Keeps `view_properties_` purely in DIP, matching `xdg_toplevel_listener.configure` in the same file and `elinux_window_drm.h` (the DRM backend already does this unconditionally — see `Width() / current_scale_` at lines 201-202 and 399-400). Also fixes a pre-existing DIP-vs-px unit mismatch in the "requested size larger than display" warning/clip path. When `force_scale_factor` is unset and `current_scale_ == 1.0` (the common case), behavior is unchanged.
2. **`CreateRenderSurface`**: when `force_scale_factor` is set and `display_max_*` are known, use `display_max_*` directly to avoid float rounding when `current_scale_` is non-integer (e.g. 1.3).

Closes #329.

Credit to @aki1770-del for the original diagnosis and patch in #20.