### PR TITLE
fix: repair three memory issues contributing to animated image leak (#429)

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
@@ -166,6 +166,16 @@ void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
 
   existing_damage->num_rects = 1;
 
+  // Free any previous allocation for this FBO. SwapBuffers normally frees the
+  // buffer after consuming it, but the engine may call populate again without
+  // a matching present_with_info (e.g. skipped frame or shutdown), which would
+  // otherwise orphan the prior malloc.
+  auto it = existing_damage_map_.find(fbo_id);
+  if (it != existing_damage_map_.end() && it->second != nullptr) {
+    free(it->second);
+    it->second = nullptr;
+  }
+
   // Allocate the array of rectangles for the existing damage.
   existing_damage_map_[fbo_id] = static_cast<FlutterRect*>(
       malloc(sizeof(FlutterRect) * existing_damage->num_rects));

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -45,7 +45,7 @@ class ELinuxWindow {
   void NotifyDisplayInfoUpdates() const {
     if (binding_handler_delegate_) {
       binding_handler_delegate_->UpdateDisplayInfo(
-          std::trunc(1000000.0 / frame_rate_), GetCurrentWidth(),
+          static_cast<double>(frame_rate_) / 1000.0, GetCurrentWidth(),
           GetCurrentHeight(), current_scale_);
     }
   }

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -269,6 +269,7 @@ const wl_callback_listener ELinuxWindowWayland::kWlSurfaceFrameListener = {
           // by all compositors. This path is for when it wasn't supported.
           auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
           if (self->wp_presentation_clk_id_ != UINT32_MAX) {
+            wl_callback_destroy(wl_callback);
             return;
           }
 


### PR DESCRIPTION
Supersedes #23 — same three fixes by @aki1770-del, split into three independent commits as I requested in [the original review](https://github.com/flutter-elinux/flutter-embedded-linux/pull/23#issuecomment-4456643421). Opening a new PR because `maintainerCanModify` returned 403 on push to his fork.

Each commit is self-contained and could be reverted individually without affecting the others.

## Commits

1. **`fix: report display refresh rate in Hz instead of mHz to Flutter engine`**
   `frame_rate_` is in mHz (from `wl_output.mode.refresh`). The previous expression `std::trunc(1000000.0 / frame_rate_)` returns ~16 for a 60 Hz display instead of 60. `FlutterEngineDisplay.refresh_rate` expects Hz, so the engine was scheduling animated image frames at the wrong cadence — likely the primary cause of the symptoms in #429.

2. **`fix: destroy wl_surface_frame callback on the wp_presentation early-return path`**
   The `.done` handler returns early when `wp_presentation` is active without destroying the `wl_callback`. The callback is registered once in `CreateRenderSurface` and never re-armed on this path, so this is one leak per `CreateRenderSurface` call (not per frame, as the original PR description suggested — see [my review](https://github.com/flutter-elinux/flutter-embedded-linux/pull/23#pullrequestreview-4295089164)).

3. **`fix: free orphaned existing_damage buffer on repeated PopulateExistingDamage`**
   `SwapBuffers` normally frees the per-FBO buffer after the engine consumes it. If the engine calls `PopulateExistingDamage` again without a matching `present_with_info` (skipped frame or shutdown), the previous allocation is silently overwritten. Defensive free before re-allocating.

Credit to @aki1770-del for the original diagnosis and patches.

Closes #429.