### PR TITLE
release scripts improvements

### DIFF
--- a/release/get-flutter-versions.sh
+++ b/release/get-flutter-versions.sh
@@ -61,7 +61,7 @@ if [ -n "$CHANNEL" ]; then
 
 	# Get SDK version
 	"$BUILD_DIR/flutter/bin/flutter" channel "$CHANNEL"
-	"$BUILD_DIR/flutter/bin/flutter" upgrade
+	"$BUILD_DIR/flutter/bin/flutter" upgrade --force
 	"$BUILD_DIR/flutter/bin/flutter" --version > "$BUILD_DIR/sdk.version"
 	git -C "$BUILD_DIR/flutter" rev-parse HEAD > "$BUILD_DIR/flutter.version"
 	git -C "$BUILD_DIR/flutter" describe --tags >> "$BUILD_DIR/flutter.version"
@@ -76,7 +76,7 @@ elif [ -n "$FLUTTER_REV" ]; then
 	fi
 	git -C "$BUILD_DIR/flutter" checkout "$FLUTTER_REV"
 
-	echo "$FLUTTER_REV" > "$BUILD_DIR/flutter.version"
+	git -C "$BUILD_DIR/flutter" rev-parse HEAD > "$BUILD_DIR/flutter.version"
 	git -C "$BUILD_DIR/flutter" describe --tags >> "$BUILD_DIR/flutter.version"
 	cat "$BUILD_DIR/flutter/bin/internal/engine.version" > "$BUILD_DIR/embedder.version"
 	ENGINE_VERSION=$(cat "$BUILD_DIR/embedder.version")

--- a/release/prepare-release.sh
+++ b/release/prepare-release.sh
@@ -73,6 +73,17 @@ Rename dir:
 mv "$dir" output-$TAG
 EOF
 		fi
+		cat <<EOF
+Update flutter-elinux:
+==================
+cat > bin/internal/engine.version <<EOT
+$(cat embedder.version)
+EOT
+cat > bin/internal/flutter.version <<EOT
+$(cat flutter.version)
+EOT
+==================
+EOF
 	)
 }
 


### PR DESCRIPTION
Minor things I had lying around to help smooth out new versions for me, shouldn't bother anyone

-------------------

- when building with a channel force upgrade to override any local change
- when building with --flutter-rev=<tag> then we still want to run rev-parse to properly fill the flutter.version file
- add snippet to update flutter-elinux version files