### PR TITLE
Allow for Skia Shader caching

### DIFF
--- a/src/client_wrapper/flutter_engine.cc
+++ b/src/client_wrapper/flutter_engine.cc
@@ -16,6 +16,12 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.assets_path = project.assets_path().c_str();
   c_engine_properties.icu_data_path = project.icu_data_path().c_str();
   c_engine_properties.aot_library_path = project.aot_library_path().c_str();
+  if (!project.persistent_cache_path().empty()) {
+    c_engine_properties.persistent_cache_path =
+        project.persistent_cache_path().c_str();
+    c_engine_properties.is_persistent_cache_read_only =
+        project.is_persistent_cache_read_only();
+  }
 
   const std::vector<std::string>& entrypoint_args =
       project.dart_entrypoint_arguments();

--- a/src/client_wrapper/include/flutter/dart_project.h
+++ b/src/client_wrapper/include/flutter/dart_project.h
@@ -41,6 +41,17 @@ class DartProject {
     return dart_entrypoint_arguments_;
   }
 
+  // Sets the Skia engine's compiled shader cache directory. App owned and
+  // only existence-verified.
+  void set_persistent_cache_path(const std::wstring& path) {
+    persistent_cache_path_ = path;
+  }
+
+  // Sets whether the persistent cache directory is read-only.
+  void set_persistent_cache_read_only(bool read_only) {
+    is_persistent_cache_read_only_ = read_only;
+  }
+
  private:
   // Accessors for internals are private, so that they can be changed if more
   // flexible options for project structures are needed later without it
@@ -53,6 +64,12 @@ class DartProject {
   const std::wstring& assets_path() const { return assets_path_; }
   const std::wstring& icu_data_path() const { return icu_data_path_; }
   const std::wstring& aot_library_path() const { return aot_library_path_; }
+  const std::wstring& persistent_cache_path() const {
+    return persistent_cache_path_;
+  }
+  bool is_persistent_cache_read_only() const {
+    return is_persistent_cache_read_only_;
+  }
 
   // The path to the assets directory.
   std::wstring assets_path_;
@@ -61,6 +78,10 @@ class DartProject {
   // The path to the AOT library. This will always return a path, but non-AOT
   // builds will not be expected to actually have a library at that path.
   std::wstring aot_library_path_;
+  // The Skia engine's compiled shader cache directory. Disabled when empty.
+  std::wstring persistent_cache_path_;
+  // Whether the shader cache directory is read-only.
+  bool is_persistent_cache_read_only_ = false;
   // The list of arguments to pass through to the Dart entrypoint.
   std::vector<std::string> dart_entrypoint_arguments_;
 };

--- a/src/flutter/shell/platform/linux_embedded/external_texture.h
+++ b/src/flutter/shell/platform/linux_embedded/external_texture.h
@@ -9,6 +9,7 @@
 
 #ifdef USE_GLES3
 #include <GLES3/gl32.h>
+
 #include <GLES2/gl2ext.h>
 #else
 #include <GLES2/gl2.h>

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
@@ -144,12 +144,11 @@ FlutterELinuxEngine::FlutterELinuxEngine(const FlutterProjectBundle& project)
 
   // Check for impeller support.
   auto& switches = project_->GetSwitches();
-  enable_impeller_ =
-      std::find_if(switches.begin(), switches.end(),
-                   [](const std::string& arg) {
-                     return arg == "--enable-impeller" ||
-                            arg == "--enable-impeller=true";
-                   }) != switches.end();
+  enable_impeller_ = std::find_if(switches.begin(), switches.end(),
+                                  [](const std::string& arg) {
+                                    return arg == "--enable-impeller" ||
+                                           arg == "--enable-impeller=true";
+                                  }) != switches.end();
 
   // Set up the legacy structs backing the API handles.
   messenger_ = FlutterDesktopMessengerReferenceOwner(

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
@@ -6,6 +6,7 @@
 
 #include <rapidjson/document.h>
 
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 
@@ -232,6 +233,20 @@ bool FlutterELinuxEngine::RunWithEntrypoint(const char* entrypoint) {
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = assets_path_string.c_str();
   args.icu_data_path = icu_path_string.c_str();
+  // We expect the App to create the cache dir, only verify the existence. See
+  // https://github.com/flutter-elinux/flutter-embedded-linux/pull/38#issuecomment-5475075925
+  const std::string& cache_path = project_->persistent_cache_path();
+  if (!cache_path.empty()) {
+    std::error_code ec;
+    if (std::filesystem::is_directory(cache_path, ec)) {
+      args.persistent_cache_path = cache_path.c_str();
+      args.is_persistent_cache_read_only =
+          project_->is_persistent_cache_read_only();
+    } else {
+      ELINUX_LOG(WARNING) << "The persistent cache directory does not exist: "
+                          << cache_path;
+    }
+  }
   args.command_line_argc = static_cast<int>(argv.size());
   args.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
   args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());

--- a/src/flutter/shell/platform/linux_embedded/flutter_project_bundle.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_project_bundle.cc
@@ -33,6 +33,11 @@ FlutterProjectBundle::FlutterProjectBundle(
   } else {
     aot_library_path_ = "";
   }
+  if (properties.persistent_cache_path != nullptr) {
+    persistent_cache_path_ =
+        ConvertWcharToString(properties.persistent_cache_path);
+  }
+  is_persistent_cache_read_only_ = properties.is_persistent_cache_read_only;
 
   for (int i = 0; i < properties.dart_entrypoint_argc; i++) {
     dart_entrypoint_arguments_.push_back(

--- a/src/flutter/shell/platform/linux_embedded/flutter_project_bundle.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_project_bundle.h
@@ -42,6 +42,14 @@ class FlutterProjectBundle {
   // Returns the path to the ICU data file.
   const std::string& icu_path() { return icu_path_; }
 
+  // Returns the shader cache directory, or an empty string when disabled.
+  const std::string& persistent_cache_path() { return persistent_cache_path_; }
+
+  // Whether the persistent cache directory is read-only.
+  bool is_persistent_cache_read_only() {
+    return is_persistent_cache_read_only_;
+  }
+
   // Returns any switches that should be passed to the engine.
   const std::vector<std::string> GetSwitches();
 
@@ -69,6 +77,12 @@ class FlutterProjectBundle {
 
   // Path to the AOT library file, if any.
   std::string aot_library_path_;
+
+  // Path to the persistent cache directory, if any.
+  std::string persistent_cache_path_;
+
+  // Whether the persistent cache directory is read-only.
+  bool is_persistent_cache_read_only_ = false;
 
   // Dart entrypoint arguments.
   std::vector<std::string> dart_entrypoint_arguments_;

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -46,6 +46,14 @@ typedef struct {
   // it will be ignored in that case.
   const wchar_t* aot_library_path;
 
+  // The path to the Skia engine's compiled shader cache directory. The app
+  // owns the directory; it is only verified to exist. This can be nullptr
+  // to disable the persistent cache. Ignored by Impeller.
+  const wchar_t* persistent_cache_path;
+
+  // Whether the shader cache directory is read-only.
+  bool is_persistent_cache_read_only;
+
   // Number of elements in the array passed in as dart_entrypoint_argv.
   int dart_entrypoint_argc;
 

--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl.cc
@@ -96,8 +96,7 @@ ContextEgl::ContextEgl(std::unique_ptr<EnvironmentEgl> environment,
 #else
     constexpr EGLint kClientVersion = 2;
     if (enable_impeller) {
-      ELINUX_LOG(ERROR)
-          << "Impeller requires GLES3; rebuild with USE_GLES3=ON";
+      ELINUX_LOG(ERROR) << "Impeller requires GLES3; rebuild with USE_GLES3=ON";
       return;
     }
 #endif


### PR DESCRIPTION
Flutter/Skia already supports persistent_cache_path, sadly not via the --cache_dir arg. So we add our own here to allow for the caching of the shaders